### PR TITLE
Add CI workflow for testing and building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# CI workflow for pull requests and pushes to non-main branches
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Clean
+        run: npm run clean
+        
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+        
+      - name: Verify package can be packed
+        run: npm pack --dry-run


### PR DESCRIPTION
This CI workflow runs tests and builds the package for pull requests and pushes to non-main branches, using Node.js versions 18 and 20.