### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cecil-ia-labs/d3-wordcloud-react/security/code-scanning/3](https://github.com/cecil-ia-labs/d3-wordcloud-react/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top level), so all jobs inherit least-privilege defaults unless overridden.  
For this CI workflow, the minimal safe setting is:

- `contents: read`

This preserves current behavior (checkout and read-only CI commands) while preventing unintended write scopes if repo/org defaults are broader now or in the future.

Edit region: near the top of `.github/workflows/ci.yml`, after `name` and before `on` (or anywhere at root level).  
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
