### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,9 @@ on:
       - v*
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: self-hosted


### PR DESCRIPTION
Potential fix for [https://github.com/cecil-ia-labs/d3-wordcloud-react/security/code-scanning/1](https://github.com/cecil-ia-labs/d3-wordcloud-react/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to only what this pipeline needs. The best minimal fix here is at workflow root (applies to all jobs) with:

- `contents: read`

This preserves existing functionality (`actions/checkout` needs contents read access) and does not grant unnecessary write scopes.  
File to change: `.github/workflows/npm-publish.yml`  
Region: after the `on:` triggers block and before `jobs:`.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
